### PR TITLE
Feature/fix gladiia inputbar comflict with QuickPanel in Cherry Studio v1.1.19

### DIFF
--- a/lib/themes/others/gladiia.ts
+++ b/lib/themes/others/gladiia.ts
@@ -28,7 +28,7 @@ export const gladiia: Theme = {
 }
 
 #inputbar {
-  margin: -15px 10px 15px 10px;
+  margin: 0px 10px 10px 10px;
   background: rgba(255,255,255,0.96) !important;
   border: 2px solid var(--color-border) !important;
   border-radius: 20px !important;

--- a/lib/themes/others/gladiia.ts
+++ b/lib/themes/others/gladiia.ts
@@ -28,7 +28,7 @@ export const gladiia: Theme = {
 }
 
 #inputbar {
-  margin:  0px 10px 10px 10px;
+  margin: -15px 10px 15px 10px;
   background: rgba(255,255,255,0.96) !important;
   border: 2px solid var(--color-border) !important;
   border-radius: 20px !important;

--- a/lib/themes/others/gladiia.ts
+++ b/lib/themes/others/gladiia.ts
@@ -28,7 +28,7 @@ export const gladiia: Theme = {
 }
 
 #inputbar {
-  margin: -15px 10px 15px 10px;
+  margin:  0px 10px 10px 10px;
   background: rgba(255,255,255,0.96) !important;
   border: 2px solid var(--color-border) !important;
   border-radius: 20px !important;


### PR DESCRIPTION
在Cherry Studio v1.1.19中，新引入了QuickPanel，这和歌蕾蒂娅-返航主题的inputbar中上边距-15px冲突，会造成QuickPanel下方的说明文字被遮挡，如下图：
![屏幕截图 2025-04-07 171304](https://github.com/user-attachments/assets/78709bc2-c8b8-489e-a43a-cc5360532009)

我修改了inputbar的margin选项，从margin: -15px 10px 10px 15px 改为 margin: 0px 10px 10px 10px，解决了重叠问题的同时适当减小了下边距使得inputbar不至于上下过窄。